### PR TITLE
Edit Encryptable, refactor methods in Cipher

### DIFF
--- a/lib/cipher.rb
+++ b/lib/cipher.rb
@@ -5,33 +5,30 @@ class Cipher
 
   def shift_chars(message, key, date)
     shift = create_shifts(key, date)
-    prepare(message).reduce([]) do |acc, char|
-        acc << new_char(char[0], shift[:a])
-        acc << new_char(char[1], shift[:b]) if char[1]
-        acc << new_char(char[2], shift[:c]) if char[2]
-        acc << new_char(char[3], shift[:d]) if char[3]
-        acc
+    prepare(message).reduce([]) do |acc, char_array|
+      char_array.each_with_index do |letter, i|
+        acc << new_char(char_array[i], shift["#{i}"]) if char_array[i]
+      end
+      acc
     end
   end
 
   def unshift_chars(message, key, date)
     shift = create_shifts(key, date)
-    prepare(message).reduce([]) do |acc, char|
-        acc << original_char(char[0], shift[:a])
-        acc << original_char(char[1], shift[:b]) if char[1]
-        acc << original_char(char[2], shift[:c]) if char[2]
-        acc << original_char(char[3], shift[:d]) if char[3]
-        acc
+    prepare(message).reduce([]) do |acc, char_array|
+      char_array.each_with_index do |letter, i|
+        acc << original_char(char_array[i], shift["#{i}"]) if char_array[i]
+      end
+      acc
     end
   end
 
   def create_shifts(key, date)
-    last_four = (date.to_i ** 2).to_s[-4..-1]
-    a = key[0..1].to_i + last_four[0].to_i
-    b = key[1..2].to_i + last_four[1].to_i
-    c = key[2..3].to_i + last_four[2].to_i
-    d = key[3..4].to_i + last_four[3].to_i
-    { a: a, b: b, c: c, d: d }
+    INDEX_RANGES.each_with_index.reduce({}) do |shifts, (range, i)|
+      shifts["#{i}"] ||= 0
+      shifts["#{i}"] = key[range].to_i + last_four(date)[i].to_i
+      shifts
+    end
   end
 
   def new_char(char, shift)

--- a/lib/encryptable.rb
+++ b/lib/encryptable.rb
@@ -3,11 +3,16 @@ require './lib/key'
 
 module Encryptable
   KEY = Key.make
+  INDEX_RANGES = [0..1, 1..2, 2..3, 3..4]
   DATE = Date.today.strftime("%d%m%y")
   ALPHA = ("a".."z").to_a << " "
 
   def prepare(message)
     split_chars = message.downcase.chars
     split_chars.each_slice(4)
+  end
+
+  def last_four(date)
+    (date.to_i ** 2).to_s[-4..-1]
   end
 end

--- a/lib/key.rb
+++ b/lib/key.rb
@@ -1,7 +1,7 @@
 class Key
   def self.make
     num = rand(99999).to_s
-    num.prepend("0") if num.length == 4
+    num.prepend("0") until num.length == 5
     num
   end
 end

--- a/test/cipher_test.rb
+++ b/test/cipher_test.rb
@@ -9,13 +9,13 @@ class CipherTest < Minitest::Test
 
   def test_create_shifts
     shifts = {
-      a: 3,
-      b: 27,
-      c: 73,
-      d: 20
+      "0"=>3,
+      "1"=>27,
+      "2"=>73,
+      "3"=>20
     }
     assert_equal shifts, @cipher.create_shifts("02715", "040895")
-    assert_equal 27, @cipher.create_shifts("02715", "040895")[:b]
+    assert_equal 27, @cipher.create_shifts("02715", "040895")["1"]
   end
 
   def test_can_prepare_message_for_encryption


### PR DESCRIPTION
Notes:

Refactored `#shift_chars` and `#unshift_chars` to use a teeny nested iteration that allows me to not have code that looks so WET... but, I think my previous method is both more readable, and I suspect a bit faster. _Maybe one day I'll learn to use `benchmark`_.

Also refactored `#create_shifts` to use an array of ranges, and create the _shifts_hash_ using number strings as keys, which enables the nested iteration I spoke of before.

But... I think a superior solution might be to use `zip` and `to_h` to create cipher alphabets with given shift number, then use `fetch` to grab the new character, combined with my previous version of `#shift_chars` and `#unshift_chars`