### PR TITLE
Create crack.rb cli runner

### DIFF
--- a/lib/crack.rb
+++ b/lib/crack.rb
@@ -1,0 +1,11 @@
+require_relative 'enigma_runner'
+
+runner = EnigmaRunner.new
+
+if ARGV[0] && ARGV[1] && ARGV[2]
+  runner.run_crack(ARGV[0], ARGV[1], ARGV[2])
+elsif ARGV[0] && ARGV[1]
+  runner.run_crack(ARGV[0], ARGV[1])
+else
+  puts "Please include input/output file names and date code. If no date is supplied, today's date is used."
+end

--- a/lib/enigma_runner.rb
+++ b/lib/enigma_runner.rb
@@ -18,6 +18,14 @@ class EnigmaRunner < Enigma
     puts "Created '#{output}' with the key #{decryption[:key]} and date #{decryption[:date]}"
   end
 
+  def run_crack(input, output, date = DATE)
+    encryption = open_read_close(input).chomp!
+    cracked = crack(encryption, date)
+    write_to_new_file(output, cracked[:decryption])
+
+    puts "Created '#{output}' with the key #{cracked[:key]} and date #{cracked[:date]}"
+  end
+
   def open_read_close(file)
     message_file = File.open(file, 'r')
     message = message_file.read

--- a/test/enigma_test.rb
+++ b/test/enigma_test.rb
@@ -80,9 +80,6 @@ class EnigmaTest < Minitest::Test
     }
 
     assert_equal encrypted, @enigma.encrypt("hello world end", "08304", "291018")
-  end
-
-  def test_can_crack_ciphertext
 
     cracked = {
       decryption: "hello world end",
@@ -91,5 +88,9 @@ class EnigmaTest < Minitest::Test
     }
 
     assert_equal cracked, @enigma.crack("vjqtbeaweqihssi", "291018")
+  end
+
+  def test_crack_again
+    assert_equal "testing cipher message! end", @enigma.crack("rusigcgpaypxcg bchsqeu!pccd", "080620")[:decryption]
   end
 end


### PR DESCRIPTION
Note:

Had a long hour where suddenly, `#crack` wasn't working when used through the CLI runner. Eventually I realized that my autosave function on Atom was adding a newline character to the end of my message files, which was throwing off the algorithm for `#crack`. 

I fixed it with a `chomp!`.. but...
How do I get autosave to stop doing that? It's not the first time it's annoyed me. @timomitchel